### PR TITLE
Firefox fix

### DIFF
--- a/stylesheets/admin/partials/_tabcontrol.sass
+++ b/stylesheets/admin/partials/_tabcontrol.sass
@@ -1,6 +1,7 @@
 #tab_control
   color: #333
   margin-bottom: 1em
+  line-height: 1.3em
   .tabs
     float: left
     width: 100%


### PR DESCRIPTION
Here's the firefox 1 liner to fix the 1px gap in the page part tabs.
